### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -30,5 +30,5 @@ def scrape_list(url)
   end
 end
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 Dir['cache/*.html'].each { |f| scrape_list(f) }


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593